### PR TITLE
feat(sentry): add SENTRY_DSN as env variable

### DIFF
--- a/build/webpack.base.js
+++ b/build/webpack.base.js
@@ -4,10 +4,13 @@ const webpack = require('webpack');
 const ESlintFormatter = require('eslint-friendly-formatter');
 const { VueLoaderPlugin } = require('vue-loader')
 
+const sentryDsn = process.env.SENTRY_DSN ? process.env.SENTRY_DSN : config.SENTRY_DSN
+
 const defaults = {
   __DEV__: JSON.stringify(config.isDev),
   __PROD__: JSON.stringify(config.isProd),
   'process.env.NODE_ENV': `"${config.env}"`,
+  '__SENTRY_DSN__': `"${sentryDsn}"`,
   __APP_MODE__: `"${config.appMode}"`,
 };
 

--- a/build/webpack.base.js
+++ b/build/webpack.base.js
@@ -4,13 +4,13 @@ const webpack = require('webpack');
 const ESlintFormatter = require('eslint-friendly-formatter');
 const { VueLoaderPlugin } = require('vue-loader')
 
-const sentryDsn = process.env.SENTRY_DSN ? process.env.SENTRY_DSN : config.SENTRY_DSN
+const sentryDsn = process.env.SENTRY_DSN ? process.env.SENTRY_DSN : ''
 
 const defaults = {
   __DEV__: JSON.stringify(config.isDev),
   __PROD__: JSON.stringify(config.isProd),
   'process.env.NODE_ENV': `"${config.env}"`,
-  '__SENTRY_DSN__': `"${sentryDsn}"`,
+  __SENTRY_DSN__: `"${sentryDsn}"`,
   __APP_MODE__: `"${config.appMode}"`,
 };
 

--- a/config/config.base.js
+++ b/config/config.base.js
@@ -9,6 +9,5 @@ module.exports = {
   debug: false,
   sessionName: 'session_id',
   credential: 'same-origin',
-  exampleAPI: exports.getURL('/thing/'),
-  SENTRY_DSN: 'https://93f5d14ba8eb424d903a1a0881d1fa6d@sentry.io/1206503'
+  exampleAPI: exports.getURL('/thing/')
 };

--- a/config/config.base.js
+++ b/config/config.base.js
@@ -9,5 +9,6 @@ module.exports = {
   debug: false,
   sessionName: 'session_id',
   credential: 'same-origin',
-  exampleAPI: exports.getURL('/thing/')
+  exampleAPI: exports.getURL('/thing/'),
+  SENTRY_DSN: 'https://93f5d14ba8eb424d903a1a0881d1fa6d@sentry.io/1206503'
 };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -29,7 +29,8 @@ import '../../node_modules/asyncy-ui-components/dist/AppFooter.css';
 import '../../node_modules/asyncy-ui-components/dist/AppHeader.css';
 import '../../node_modules/asyncy-ui-components/dist/css/global.css';
 
-Raven.config('https://93f5d14ba8eb424d903a1a0881d1fa6d@sentry.io/1206503', {
+/* global __SENTRY_DSN__ */
+Raven.config(__SENTRY_DSN__, {
   environment: process.env.NODE_ENV,
 }).addPlugin(RavenVue, Vue)
   .install();


### PR DESCRIPTION
- add webpack `__SENTRY_DSN__` global variable
- add default sentry value in `config.base.js` if `process.env.SENTRY_DSN` is undefined
- use `__SENTRY_DSN` in `main.js`

should fix issue #26 

@stevepeak should I let the default value in the config file or should I remove it ?